### PR TITLE
feat: add backend content filtering by job position and owner for employee view limits

### DIFF
--- a/apps/api/src/routers/content.ts
+++ b/apps/api/src/routers/content.ts
@@ -18,6 +18,10 @@ export const contentRouter = router({
       where.content_owner = input.content_owner;
     }
 
+    if (input.job_position) {
+      where.job_position = input.job_position;
+    }
+
     if (input.search) {
       where.OR = [
         { filename: { contains: input.search, mode: "insensitive" } },

--- a/packages/types/src/schemas/content.ts
+++ b/packages/types/src/schemas/content.ts
@@ -21,6 +21,7 @@ export const updateContentSchema = createContentSchema.omit({ fileID: true }).pa
 export const contentListQuerySchema = z.object({
   document_status: z.string().optional(),
   content_owner: z.string().optional(),
+  job_position: z.string().optional(),
   search: z.string().optional(),
 });
 


### PR DESCRIPTION
**Description:**
Closes #18
Added backend filtering support to limit content visibility per employee role. The content list endpoint now accepts job_position as an optional filter parameter in addition to the existing content_owner filter. Filtering is handled entirely on the backend in Prisma so content is never sent to the frontend unnecessarily.

**Changes made:**
Added job_position to contentListQuerySchema in packages/types/schemas/content.ts
Added job_position where clause to content list query in apps/api/src/routers/content.ts

This is ready to be connected once login backend and frontend connection issues are complete. See issue 18 comments for integration instructions.