### PR TITLE
Completed 4d + reduced complexity for content items

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -556,12 +556,13 @@ model ContentManagement {
   content_type    String?      @db.VarChar(20)
   document_status String?      @db.VarChar(20)
   is_favorited    Boolean      @default(false)
-  is_checked_out  Boolean      @default(false)
-  checked_out_by  String?      @db.Uuid
-  checked_out_at  DateTime?    @db.Timestamptz(6)
-  owner_id        String?      @map("owner_id") @db.Uuid
-  owner           UserProfile? @relation(fields: [owner_id], references: [id], onUpdate: NoAction)
-  content_tags    ContentTag[]
+  is_checked_out       Boolean      @default(false)
+  checked_out_by       String?      @db.Uuid
+  checked_out_at       DateTime?    @db.Timestamptz(6)
+  owner_id             String?      @map("owner_id") @db.Uuid
+  owner                UserProfile? @relation("OwnedContent", fields: [owner_id], references: [id], onUpdate: NoAction)
+  checked_out_by_user  UserProfile? @relation("CheckedOutContent", fields: [checked_out_by], references: [id], onUpdate: NoAction)
+  content_tags         ContentTag[]
 
   @@map("content_management")
   @@schema("public")
@@ -601,8 +602,9 @@ model UserProfile {
   employee_code String?             @unique @db.VarChar(10)
   job_desc      String?             @db.VarChar(200)
   photo_url     String?             @db.VarChar(500)
-  owned_content ContentManagement[]
-  auth_user     auth_users          @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  owned_content      ContentManagement[] @relation("OwnedContent")
+  checkedOutContent  ContentManagement[] @relation("CheckedOutContent")
+  auth_user          auth_users          @relation(fields: [id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   metricsEvents MetricsEvent[]
   auditEvents   AuditEvent[]

--- a/apps/api/src/routers/content.ts
+++ b/apps/api/src/routers/content.ts
@@ -14,6 +14,11 @@ const ownerSelect = {
   role: true,
 } as const;
 
+const checkedOutByUserSelect = {
+  id: true,
+  name: true,
+} as const;
+
 const tagsInclude = {
   content_tags: {
     include: {
@@ -25,10 +30,12 @@ const tagsInclude = {
 function assertCanEdit(
   file: { is_checked_out: boolean; checked_out_by: string | null } | null,
   userId: string,
+  userRole?: string | null,
 ) {
   if (!file) throw new Error("File not found");
-  if (file.is_checked_out && file.checked_out_by !== userId) {
-    throw new Error("This file is checked out by another user");
+  if (userRole === "admin") return;
+  if (!file.is_checked_out || file.checked_out_by !== userId) {
+    throw new Error("You must check out this item before modifying or deleting it");
   }
 }
 
@@ -182,6 +189,7 @@ export const contentRouter = router({
       orderBy: [{ is_favorited: "desc" }, { last_modified: "desc" }],
       include: {
         owner: { select: ownerSelect },
+        checked_out_by_user: { select: checkedOutByUserSelect },
         ...tagsInclude,
       },
     });
@@ -208,6 +216,7 @@ export const contentRouter = router({
             job_desc: true,
           },
         },
+        checked_out_by_user: { select: checkedOutByUserSelect },
         ...tagsInclude,
       },
     });
@@ -234,6 +243,7 @@ export const contentRouter = router({
           : data,
       include: {
         owner: { select: ownerSelect },
+        checked_out_by_user: { select: checkedOutByUserSelect },
         ...tagsInclude,
       },
     });
@@ -265,7 +275,7 @@ export const contentRouter = router({
         where: { fileID },
       });
 
-      assertCanEdit(file, userId);
+      assertCanEdit(file, userId, userRole);
 
       if (!canEditForRole(userRole, file?.job_position)) {
         throw new Error("You do not have permission to edit this content");
@@ -285,6 +295,7 @@ export const contentRouter = router({
               } as Prisma.ContentManagementUpdateInput,
               include: {
                 owner: { select: ownerSelect },
+                checked_out_by_user: { select: checkedOutByUserSelect },
                 ...tagsInclude,
               },
             })
@@ -296,6 +307,7 @@ export const contentRouter = router({
               } as Prisma.ContentManagementUncheckedUpdateInput,
               include: {
                 owner: { select: ownerSelect },
+                checked_out_by_user: { select: checkedOutByUserSelect },
                 ...tagsInclude,
               },
             });
@@ -316,12 +328,15 @@ export const contentRouter = router({
     const userId = ctx.user?.id;
     if (!userId) throw new Error("Not authenticated");
 
+    const profile = ctx.profile as { role: string | null } | null;
+    const userRole = profile?.role;
+
     const file = await ctx.prisma.contentManagement.findUnique({
       where: { fileID: input.fileID },
     });
 
     if (!file) throw new Error("File not found");
-    assertCanEdit(file, userId);
+    assertCanEdit(file, userId, userRole);
 
     const result = await ctx.prisma.contentManagement.delete({
       where: { fileID: input.fileID },

--- a/apps/web/src/pages/content/components/ContentCard.tsx
+++ b/apps/web/src/pages/content/components/ContentCard.tsx
@@ -35,7 +35,7 @@ export function ContentCard({
   const visibleTags = tags.slice(0, MAX_VISIBLE_TAGS);
   const hiddenCount = tags.length - MAX_VISIBLE_TAGS;
 
-  const isCheckedOutByMe = item.is_checked_out && item.checked_out_by === currentUserId;
+  const isCheckedOutByMe = !!(item.is_checked_out && item.checked_out_by === currentUserId);
   const checkedOutByName = item.checked_out_by_user?.name;
 
   return (

--- a/apps/web/src/pages/content/components/ContentCard.tsx
+++ b/apps/web/src/pages/content/components/ContentCard.tsx
@@ -1,21 +1,42 @@
-import { Lock } from "lucide-react";
+import { Lock, Unlock } from "lucide-react";
 import { Link } from "react-router";
 import type { ContentItem } from "@/types/content";
 import { renderTag } from "@/utils/tag";
 
+type CheckinMutation = {
+  mutate: (args: { fileID: string }) => void;
+};
+
 type Props = {
   item: ContentItem;
+  currentUserId?: string;
   toggleFavorite: {
     mutate: (args: { fileID: string; is_favorited: boolean }) => void;
   };
+  checkin: CheckinMutation;
   getStatusBadge: (status?: string) => string;
 };
 
-export function ContentCard({ item, toggleFavorite, getStatusBadge }: Props) {
+function checkedOutLabel(isCheckedOutByMe: boolean, name: string | undefined): string {
+  if (isCheckedOutByMe) return "Checked out by you";
+  if (name) return `Checked out by ${name}`;
+  return "Checked out";
+}
+
+export function ContentCard({
+  item,
+  currentUserId,
+  toggleFavorite,
+  checkin,
+  getStatusBadge,
+}: Props) {
   const MAX_VISIBLE_TAGS = 3;
   const tags = item.content_tags ?? [];
   const visibleTags = tags.slice(0, MAX_VISIBLE_TAGS);
   const hiddenCount = tags.length - MAX_VISIBLE_TAGS;
+
+  const isCheckedOutByMe = item.is_checked_out && item.checked_out_by === currentUserId;
+  const checkedOutByName = item.checked_out_by_user?.name;
 
   return (
     <Link
@@ -109,9 +130,24 @@ export function ContentCard({ item, toggleFavorite, getStatusBadge }: Props) {
 
       {/* CHECKED OUT */}
       {item.is_checked_out && (
-        <div className="mb-2 flex items-center gap-1.5 rounded bg-amber-50 px-2 py-1 text-xs font-semibold text-amber-700">
-          <Lock className="h-3 w-3" />
-          Checked out
+        <div className="mb-2 flex items-center justify-between gap-2 rounded bg-amber-50 px-2 py-1">
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-amber-700">
+            <Lock className="h-3 w-3" />
+            {checkedOutLabel(isCheckedOutByMe, checkedOutByName)}
+          </div>
+          {isCheckedOutByMe && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.preventDefault();
+                checkin.mutate({ fileID: item.fileID });
+              }}
+              className="inline-flex items-center gap-1 rounded bg-amber-200 px-2 py-0.5 text-xs font-semibold text-amber-900 transition-colors hover:bg-amber-300"
+            >
+              <Unlock className="h-3 w-3" />
+              Check In
+            </button>
+          )}
         </div>
       )}
 

--- a/apps/web/src/pages/content/components/ContentGrid.tsx
+++ b/apps/web/src/pages/content/components/ContentGrid.tsx
@@ -7,6 +7,10 @@ type ToggleFavorite = {
   mutate: (args: { fileID: string; is_favorited: boolean }) => void;
 };
 
+type CheckinMutation = {
+  mutate: (args: { fileID: string }) => void;
+};
+
 type StatusFn = (status?: string) => string;
 
 type Filters = {
@@ -19,7 +23,9 @@ type Props = {
   };
   filtered: ContentItem[];
   filters: Filters;
+  currentUserId?: string;
   toggleFavorite: ToggleFavorite;
+  checkin: CheckinMutation;
   getStatusBadge: StatusFn;
 };
 
@@ -27,7 +33,9 @@ export function ContentGrid({
   contents,
   filtered,
   filters,
+  currentUserId,
   toggleFavorite,
+  checkin,
   getStatusBadge,
 }: Props) {
   return (
@@ -49,14 +57,18 @@ export function ContentGrid({
               <ContentCard
                 key={item.fileID}
                 item={item}
+                currentUserId={currentUserId}
                 toggleFavorite={toggleFavorite}
+                checkin={checkin}
                 getStatusBadge={getStatusBadge}
               />
             ) : (
               <ContentListItem
                 key={item.fileID}
                 item={item}
+                currentUserId={currentUserId}
                 toggleFavorite={toggleFavorite}
+                checkin={checkin}
                 getStatusBadge={getStatusBadge}
               />
             ),

--- a/apps/web/src/pages/content/components/ContentListItem.tsx
+++ b/apps/web/src/pages/content/components/ContentListItem.tsx
@@ -1,4 +1,4 @@
-import { Lock } from "lucide-react";
+import { Lock, Unlock } from "lucide-react";
 import { Link } from "react-router";
 import type { ContentItem } from "@/types/content";
 import { renderTag } from "@/utils/tag";
@@ -7,17 +7,38 @@ type ToggleFavorite = {
   mutate: (args: { fileID: string; is_favorited: boolean }) => void;
 };
 
+type CheckinMutation = {
+  mutate: (args: { fileID: string }) => void;
+};
+
 type Props = {
   item: ContentItem;
+  currentUserId?: string;
   toggleFavorite: ToggleFavorite;
+  checkin: CheckinMutation;
   getStatusBadge: (status?: string) => string;
 };
 
-export function ContentListItem({ item, toggleFavorite, getStatusBadge }: Props) {
+function checkedOutLabel(isCheckedOutByMe: boolean, name: string | undefined): string {
+  if (isCheckedOutByMe) return "Checked out by you";
+  if (name) return `Checked out by ${name}`;
+  return "Checked out";
+}
+
+export function ContentListItem({
+  item,
+  currentUserId,
+  toggleFavorite,
+  checkin,
+  getStatusBadge,
+}: Props) {
   const MAX_VISIBLE_TAGS = 3;
   const tags = item.content_tags ?? [];
   const visibleTags = tags.slice(0, MAX_VISIBLE_TAGS);
   const hiddenCount = tags.length - MAX_VISIBLE_TAGS;
+
+  const isCheckedOutByMe = item.is_checked_out && item.checked_out_by === currentUserId;
+  const checkedOutByName = item.checked_out_by_user?.name;
 
   return (
     <Link
@@ -56,9 +77,24 @@ export function ContentListItem({ item, toggleFavorite, getStatusBadge }: Props)
       {/* RIGHT SIDE */}
       <div className="flex items-center gap-2">
         {item.is_checked_out && (
-          <div className="flex items-center gap-1 rounded bg-amber-50 px-2 py-1 text-xs font-semibold text-amber-700">
-            <Lock className="h-3 w-3" />
-            Checked out
+          <div className="flex items-center gap-1.5 rounded bg-amber-50 px-2 py-1">
+            <div className="flex items-center gap-1 text-xs font-semibold text-amber-700">
+              <Lock className="h-3 w-3" />
+              {checkedOutLabel(isCheckedOutByMe, checkedOutByName)}
+            </div>
+            {isCheckedOutByMe && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  checkin.mutate({ fileID: item.fileID });
+                }}
+                className="inline-flex items-center gap-1 rounded bg-amber-200 px-2 py-0.5 text-xs font-semibold text-amber-900 transition-colors hover:bg-amber-300"
+              >
+                <Unlock className="h-3 w-3" />
+                Check In
+              </button>
+            )}
           </div>
         )}
 

--- a/apps/web/src/pages/content/components/ContentListItem.tsx
+++ b/apps/web/src/pages/content/components/ContentListItem.tsx
@@ -37,7 +37,7 @@ export function ContentListItem({
   const visibleTags = tags.slice(0, MAX_VISIBLE_TAGS);
   const hiddenCount = tags.length - MAX_VISIBLE_TAGS;
 
-  const isCheckedOutByMe = item.is_checked_out && item.checked_out_by === currentUserId;
+  const isCheckedOutByMe = !!(item.is_checked_out && item.checked_out_by === currentUserId);
   const checkedOutByName = item.checked_out_by_user?.name;
 
   return (

--- a/apps/web/src/pages/content/content-form.tsx
+++ b/apps/web/src/pages/content/content-form.tsx
@@ -61,8 +61,6 @@ type ContentFormFieldsProps = {
   isSaving: boolean;
   onDelete: () => void;
   onSubmit: (e: React.FormEvent) => void;
-  isCheckedOut: boolean;
-  isCheckedOutByMe: boolean;
 };
 
 function ContentMetadataReadonlyTable({
@@ -240,8 +238,6 @@ function ContentFormSummarySection({
   mutationError,
   submitLabel,
   onDelete,
-  isCheckedOut,
-  isCheckedOutByMe,
 }: {
   filename: string;
   url: string;
@@ -265,8 +261,6 @@ function ContentFormSummarySection({
   mutationError: string;
   submitLabel: string;
   onDelete: () => void;
-  isCheckedOut: boolean;
-  isCheckedOutByMe: boolean;
 }) {
   return (
     <>
@@ -310,7 +304,7 @@ function ContentFormSummarySection({
           <button
             type="button"
             onClick={() => onDelete()}
-            disabled={isSaving || isUploading || isCheckedOut || isCheckedOutByMe}
+            disabled={isSaving || isUploading}
             className="inline-flex shrink-0 items-center justify-center gap-2 rounded-md bg-red-500 px-6 py-3 font-semibold text-white transition-colors hover:bg-red-500/90 disabled:opacity-60"
           >
             {(isSaving || isUploading) && <Loader2 className="h-4 w-4 animate-spin" />}
@@ -633,8 +627,6 @@ function ContentFormFields({
   isSaving,
   onDelete,
   onSubmit,
-  isCheckedOut,
-  isCheckedOutByMe,
 }: ContentFormFieldsProps) {
   const [metadataEditMode, setMetadataEditMode] = useState(false);
   const showFileSummary = isEditing && Boolean(url) && !metadataEditMode;
@@ -729,8 +721,6 @@ function ContentFormFields({
                 mutationError={mutationError}
                 submitLabel={submitLabel}
                 onDelete={onDelete}
-                isCheckedOut={isCheckedOut}
-                isCheckedOutByMe={isCheckedOutByMe}
               />
             ) : (
               <ContentFormDraftSection
@@ -892,12 +882,20 @@ function ContentFormPage() {
   const isCheckedOut = existing.data?.is_checked_out ?? false;
   const checkedOutBy = existing.data?.checked_out_by ?? null;
   const contentJobPosition = existing.data?.job_position;
-  const canEdit =
-    !isEditing ||
+  const isCheckedOutByMe = isCheckedOut && checkedOutBy === currentUserId;
+  const isLockedByOther = isCheckedOut && !isCheckedOutByMe;
+
+  // Role-based permission: does the user's role match the content's job position?
+  // This determines whether they can check out the item at all.
+  const hasRoleAccess =
     userRole === "admin" ||
-    (!isCheckedOut &&
-      (!contentJobPosition?.trim() ||
-        (!!userRole && normalizeRole(userRole) === normalizeRole(contentJobPosition))));
+    !contentJobPosition?.trim() ||
+    (!!userRole && normalizeRole(userRole) === normalizeRole(contentJobPosition));
+
+  // canEdit: may modify form fields / save / delete.
+  // Per spec: item must be checked out by this user first.
+  // Admin bypass remains so admins can recover from bad states.
+  const canEdit = !isEditing || userRole === "admin" || (hasRoleAccess && isCheckedOutByMe);
 
   const checkout = trpc.content.checkout.useMutation({
     onSuccess: () => {
@@ -919,9 +917,6 @@ function ContentFormPage() {
       utils.content.list.invalidate();
     },
   });
-
-  const isCheckedOutByMe = isCheckedOut && checkedOutBy === currentUserId;
-  const isLockedByOther = isCheckedOut && !isCheckedOutByMe;
 
   const isSaving = create.isPending || update.isPending;
 
@@ -973,18 +968,22 @@ function ContentFormPage() {
     <>
       {isEditing && (
         <div className="mx-auto max-w-4xl px-4 pt-4 sm:px-6 lg:px-8">
-          {!canEdit && (
+          {!hasRoleAccess && (
             <div className="mb-4 flex items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive">
               <Lock className="h-4 w-4 shrink-0" />
               You do not have permission to edit this content. Only the assigned employee type can
               make changes.
             </div>
           )}
-          {canEdit && isLockedByOther && (
+          {hasRoleAccess && isLockedByOther && (
             <div className="mb-4 flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-950">
               <div className="flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-200">
                 <Lock className="h-4 w-4" />
-                This file is checked out by another user. Editing is disabled.
+                This file is checked out by
+                {existing.data?.checked_out_by_user?.name
+                  ? ` ${existing.data.checked_out_by_user.name}`
+                  : " another user"}
+                . Editing is disabled.
               </div>
               {session?.user?.user_metadata?.role === "admin" && (
                 <button
@@ -1003,20 +1002,20 @@ function ContentFormPage() {
               )}
             </div>
           )}
-          {canEdit && !isLockedByOther && (
+          {hasRoleAccess && !isLockedByOther && (
             <div className="mb-4 flex items-center justify-between rounded-lg border border-border bg-muted/30 px-4 py-3">
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 {isCheckedOutByMe ? (
                   <>
                     <Lock className="h-4 w-4 text-hanover-green" />
                     <span className="font-medium text-hanover-green">
-                      You have this file checked out
+                      You have this file checked out — you may now edit or delete it
                     </span>
                   </>
                 ) : (
                   <>
                     <Unlock className="h-4 w-4" />
-                    <span>File is available</span>
+                    <span>File is available. Check it out before editing or deleting.</span>
                   </>
                 )}
               </div>
@@ -1091,8 +1090,6 @@ function ContentFormPage() {
         updateError={update.error}
         isSaving={isSaving}
         onDelete={handleDelete}
-        isCheckedOut={isCheckedOut}
-        isCheckedOutByMe={isCheckedOutByMe}
         onSubmit={handleSubmit}
       />
       {askConfirmation && (

--- a/apps/web/src/pages/content/page.tsx
+++ b/apps/web/src/pages/content/page.tsx
@@ -1,6 +1,7 @@
 import { Plus, Search } from "lucide-react";
 import { useState } from "react";
 import { Link } from "react-router";
+import { useSession } from "@/auth/session-context";
 import { trpc } from "@/lib/trpc.ts";
 import { normalizeContent } from "@/utils/normalizeContent.ts";
 import { ContentFilters } from "./components/ContentFilters";
@@ -34,6 +35,8 @@ export default function ContentPage() {
   trpc.user.myAccess.useQuery();
   const filters = useContentFilters();
   const debouncedSearch = useDebouncedValue(filters.search, 300);
+  const { session } = useSession();
+  const currentUserId = session?.user?.id;
 
   const [openRole, setOpenRole] = useState(true);
   const [openStatus, setOpenStatus] = useState(true);
@@ -43,6 +46,10 @@ export default function ContentPage() {
   const utils = trpc.useUtils();
 
   const toggleFavorite = trpc.content.update.useMutation({
+    onSuccess: () => utils.content.list.invalidate(),
+  });
+
+  const checkin = trpc.content.checkin.useMutation({
     onSuccess: () => utils.content.list.invalidate(),
   });
 
@@ -121,7 +128,9 @@ export default function ContentPage() {
             contents={contents}
             filtered={filtered}
             filters={filters}
+            currentUserId={currentUserId}
             toggleFavorite={toggleFavorite}
+            checkin={checkin}
             getStatusBadge={getStatusBadge}
           />
         </div>

--- a/apps/web/src/types/content.ts
+++ b/apps/web/src/types/content.ts
@@ -6,6 +6,9 @@ export type ContentItem = {
   job_position?: string;
   is_favorited?: boolean;
   is_checked_out?: boolean;
+  checked_out_by?: string | null;
+  checked_out_by_user?: { id: string; name: string } | null;
+  checked_out_at?: string | null;
   last_modified?: string;
   owner?: { name?: string };
   content_tags?: { tag: { id: number; name: string } }[];

--- a/apps/web/src/utils/normalizeContent.ts
+++ b/apps/web/src/utils/normalizeContent.ts
@@ -17,6 +17,9 @@ export function normalizeContent(item: unknown): ContentItem {
     job_position: data.job_position ?? undefined,
     is_favorited: data.is_favorited ?? undefined,
     is_checked_out: data.is_checked_out ?? undefined,
+    checked_out_by: data.checked_out_by ?? null,
+    checked_out_by_user: data.checked_out_by_user ?? null,
+    checked_out_at: data.checked_out_at ?? null,
     last_modified: data.last_modified ?? undefined,
 
     owner: data.owner ?? undefined,


### PR DESCRIPTION
- Enforce checkout requirement on backend — `update` and `delete` now reject unless the file is checked out by the requesting user (admin bypass preserved)
- Add Prisma `checked_out_by_user` relation between `ContentManagement` and `UserProfile`
- Include `checked_out_by_user { id, name }` in `list`, `getById`, `create`, and `update` responses
- Extend frontend `ContentItem` type and `normalizeContent` with `checked_out_by`, `checked_out_by_user`, and `checked_out_at`
- Show "Checked out by you" / "Checked out by [name]" in `ContentCard` and `ContentListItem`
- Add inline Check In button to card and list views so users can check in from the listing
- Thread `currentUserId` and `checkin` mutation through `page.tsx` → `ContentGrid` → card/list components
- Split edit permission into `hasRoleAccess` (gates Check Out button visibility) and `canEdit` (gates Save/Delete, requires `isCheckedOutByMe`)
- Update edit-page banners to reflect the three states: no role access, locked by other user (shows name), available/checked-out-by-me
- Fix Delete button disabled logic that previously blocked delete when the user had the file checked out
- Remove unused `isCheckedOut` / `isCheckedOutByMe` props from `ContentFormSummarySection` pass-through chain
- Extract `checkedOutLabel()` helper in card/list components to reduce cognitive complexity below lint threshold