### PR TITLE
feat: add OCR-powered full-text document search

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,7 +23,8 @@
     "db:migrate": "node --import ./load-env-pre.js ./node_modules/prisma/build/index.js migrate dev",
     "db:seed": "tsx prisma/seed.ts",
     "db:seed:remote": "node --import ./run-prisma-remote.js --import ./load-env-pre.js ./node_modules/prisma/build/index.js db seed",
-    "db:studio": "node --import ./load-env-pre.js ./node_modules/prisma/build/index.js studio"
+    "db:studio": "node --import ./load-env-pre.js ./node_modules/prisma/build/index.js studio",
+    "ocr:backfill": "tsx src/scripts/backfill-ocr.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
@@ -36,11 +37,17 @@
     "@supabase/supabase-js": "^2.49.0",
     "@trpc/server": "^11.0.0",
     "dotenv": "^16.6.1",
+    "jszip": "^3.10.1",
+    "mammoth": "^1.12.0",
+    "pdfjs-dist": "^5.7.284",
     "pg": "^8.20.0",
     "prisma": "^7.6.0",
+    "tesseract.js": "^7.0.0",
+    "xlsx": "^0.18.5",
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@types/jszip": "^3.4.1",
     "@types/node": "^22.0.0",
     "@types/pg": "^8.20.0",
     "esbuild": "^0.28.0",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -546,6 +546,17 @@ model webauthn_credentials {
   @@schema("auth")
 }
 
+enum OcrStatus {
+  pending
+  processing
+  done
+  failed
+  skipped
+
+  @@map("ocr_status")
+  @@schema("public")
+}
+
 model ContentManagement {
   fileID              String       @id @map("fileid") @db.Char(64)
   filename            String?      @db.VarChar(100)
@@ -560,6 +571,10 @@ model ContentManagement {
   checked_out_by      String?      @db.Uuid
   checked_out_at      DateTime?    @db.Timestamptz(6)
   owner_id            String?      @map("owner_id") @db.Uuid
+  extracted_text      String?      @db.Text
+  ocr_status          OcrStatus    @default(pending)
+  ocr_error           String?      @db.Text
+  ocr_updated_at      DateTime?    @db.Timestamptz(6)
   owner               UserProfile? @relation("OwnedContent", fields: [owner_id], references: [id], onUpdate: NoAction)
   checked_out_by_user UserProfile? @relation("CheckedOutContent", fields: [checked_out_by], references: [id], onUpdate: NoAction)
   content_tags        ContentTag[]

--- a/apps/api/src/routers/content.ts
+++ b/apps/api/src/routers/content.ts
@@ -8,6 +8,7 @@ import {
 } from "@myapp/types/schemas";
 import type { Prisma } from "@prisma/client";
 import { publicProcedure, router } from "../lib/trpc";
+import { enqueueOcr } from "../services/ocr-queue";
 
 const ownerSelect = {
   id: true,
@@ -210,11 +211,34 @@ export const contentRouter = router({
       };
     }
 
+    // Map of fileID → matchedInContent (true when hit came from body, not title)
+    const matchedInContentMap = new Map<string, boolean>();
+
     if (input.search) {
-      where.OR = [
-        { filename: { contains: input.search, mode: "insensitive" } },
-        { url: { contains: input.search, mode: "insensitive" } },
-      ];
+      type FtsRow = { fileid: string; matched_in_content: boolean };
+      const ftsRows = await ctx.prisma.$queryRaw<FtsRow[]>`
+        SELECT
+          fileid,
+          (
+            to_tsvector('english', coalesce(extracted_text, ''))
+              @@ plainto_tsquery('english', ${input.search})
+            AND NOT
+            to_tsvector('english', coalesce(filename, ''))
+              @@ plainto_tsquery('english', ${input.search})
+          ) AS matched_in_content
+        FROM content_management
+        WHERE search_vector @@ plainto_tsquery('english', ${input.search})
+      `;
+
+      if (ftsRows.length === 0) {
+        return [];
+      }
+
+      for (const row of ftsRows) {
+        matchedInContentMap.set(row.fileid.trim(), row.matched_in_content);
+      }
+
+      where.fileID = { in: [...matchedInContentMap.keys()] };
     }
 
     if (input.format && input.format in FORMAT_GROUPS) {
@@ -279,6 +303,7 @@ export const contentRouter = router({
       .map((r) => ({
         ...r,
         is_favorited: (r.favoritedBy?.length ?? 0) > 0,
+        matched_in_content: matchedInContentMap.get(r.fileID) ?? false,
       }))
       .sort((a, b) => {
         // 1. favorites first
@@ -316,6 +341,7 @@ export const contentRouter = router({
         checked_out_by_user: { select: checkedOutByUserSelect },
         ...tagsInclude,
       },
+      // extracted_text and ocr_status are plain scalar fields — included by default.
     });
   }),
 
@@ -357,6 +383,9 @@ export const contentRouter = router({
       },
     });
 
+    // Kick off background OCR — fire-and-forget, does not block the response.
+    enqueueOcr(result.fileID);
+
     return result;
   }),
 
@@ -383,6 +412,17 @@ export const contentRouter = router({
 
       if (!canEditForRole(userRole, file?.job_position)) {
         throw new Error("You do not have permission to edit this content");
+      }
+
+      const urlChanged = data.url !== undefined && data.url !== file?.url;
+
+      // If the file URL changed, reset OCR so the new file gets re-extracted.
+      if (urlChanged) {
+        (
+          data as typeof data & { extracted_text?: null; ocr_status?: string; ocr_error?: null }
+        ).extracted_text = null;
+        (data as typeof data & { ocr_status?: string }).ocr_status = "pending";
+        (data as typeof data & { ocr_error?: null }).ocr_error = null;
       }
 
       const result =
@@ -424,6 +464,9 @@ export const contentRouter = router({
           fileName: result.filename,
         },
       });
+
+      // Re-run OCR if the file URL changed.
+      if (urlChanged) enqueueOcr(fileID);
 
       return result;
     }),

--- a/apps/api/src/scripts/backfill-ocr.ts
+++ b/apps/api/src/scripts/backfill-ocr.ts
@@ -1,0 +1,91 @@
+/**
+ * One-time backfill: process all existing documents whose OCR status is
+ * 'pending' or 'failed'. Run with:
+ *
+ *   pnpm --filter @myapp/api tsx src/scripts/backfill-ocr.ts
+ *
+ * Re-running is safe — it only processes pending/failed records.
+ */
+
+import "../load-env.ts";
+import { prisma } from "../lib/prisma";
+import { extractText } from "../services/ocr";
+
+const BATCH_SIZE = 5;
+
+async function main() {
+  const records = await prisma.contentManagement.findMany({
+    where: { ocr_status: { in: ["pending", "failed"] } },
+    select: { fileID: true, url: true, format: true, filename: true },
+    orderBy: { fileID: "asc" },
+  });
+
+  console.log(`[backfill] ${records.length} records to process`);
+
+  let done = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (let i = 0; i < records.length; i += BATCH_SIZE) {
+    const batch = records.slice(i, i + BATCH_SIZE);
+
+    await Promise.all(
+      batch.map(async (record) => {
+        if (!record.url) {
+          await prisma.contentManagement.update({
+            where: { fileID: record.fileID },
+            data: { ocr_status: "skipped", ocr_updated_at: new Date() },
+          });
+          skipped++;
+          return;
+        }
+
+        await prisma.contentManagement.update({
+          where: { fileID: record.fileID },
+          data: { ocr_status: "processing" },
+        });
+
+        try {
+          const { text, skipped: isSkipped } = await extractText(record.url, record.format);
+
+          await prisma.contentManagement.update({
+            where: { fileID: record.fileID },
+            data: {
+              extracted_text: text,
+              ocr_status: isSkipped ? "skipped" : "done",
+              ocr_error: null,
+              ocr_updated_at: new Date(),
+            },
+          });
+
+          if (isSkipped) skipped++;
+          else done++;
+
+          console.log(
+            `[backfill] ✓ ${record.filename ?? record.fileID} (${isSkipped ? "skipped" : "done"})`,
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          await prisma.contentManagement.update({
+            where: { fileID: record.fileID },
+            data: { ocr_status: "failed", ocr_error: message, ocr_updated_at: new Date() },
+          });
+          failed++;
+          console.error(`[backfill] ✗ ${record.filename ?? record.fileID}: ${message}`);
+        }
+      }),
+    );
+
+    console.log(
+      `[backfill] progress: ${Math.min(i + BATCH_SIZE, records.length)}/${records.length}`,
+    );
+  }
+
+  console.log(`\n[backfill] complete — done: ${done}, skipped: ${skipped}, failed: ${failed}`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/api/src/services/ocr-queue.ts
+++ b/apps/api/src/services/ocr-queue.ts
@@ -1,0 +1,62 @@
+import { prisma } from "../lib/prisma";
+import { extractText } from "./ocr";
+
+// Track in-flight jobs so we don't double-queue the same file.
+const inFlight = new Set<string>();
+
+/**
+ * Fire-and-forget: enqueue a file for OCR extraction.
+ * Returns immediately; the extraction runs in the background.
+ */
+export function enqueueOcr(fileID: string): void {
+  if (inFlight.has(fileID)) return;
+  inFlight.add(fileID);
+
+  runOcr(fileID).finally(() => inFlight.delete(fileID));
+}
+
+async function runOcr(fileID: string): Promise<void> {
+  const record = await prisma.contentManagement.findUnique({
+    where: { fileID },
+    select: { url: true, format: true },
+  });
+
+  if (!record?.url) {
+    await prisma.contentManagement.update({
+      where: { fileID },
+      data: { ocr_status: "skipped", ocr_updated_at: new Date() },
+    });
+    return;
+  }
+
+  await prisma.contentManagement.update({
+    where: { fileID },
+    data: { ocr_status: "processing", ocr_error: null },
+  });
+
+  try {
+    const { text, skipped } = await extractText(record.url, record.format);
+
+    await prisma.contentManagement.update({
+      where: { fileID },
+      data: {
+        extracted_text: text,
+        ocr_status: skipped ? "skipped" : "done",
+        ocr_error: null,
+        ocr_updated_at: new Date(),
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[ocr] failed for ${fileID}:`, message);
+
+    await prisma.contentManagement.update({
+      where: { fileID },
+      data: {
+        ocr_status: "failed",
+        ocr_error: message,
+        ocr_updated_at: new Date(),
+      },
+    });
+  }
+}

--- a/apps/api/src/services/ocr.ts
+++ b/apps/api/src/services/ocr.ts
@@ -1,0 +1,153 @@
+import { createWorker } from "tesseract.js";
+import * as XLSX from "xlsx";
+
+// Lazy singleton Tesseract worker — initialising one per call is too slow.
+let tesseractWorker: Awaited<ReturnType<typeof createWorker>> | null = null;
+
+async function getTesseractWorker() {
+  if (!tesseractWorker) {
+    tesseractWorker = await createWorker("eng");
+  }
+  return tesseractWorker;
+}
+
+async function fetchBuffer(url: string): Promise<Buffer> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch file: ${res.status} ${res.statusText}`);
+  const arrayBuffer = await res.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+async function extractFromPdf(buf: Buffer): Promise<string | null> {
+  // Dynamic import so pdfjs-dist (which uses globalThis) only loads when needed.
+  const pdfjsLib = await import("pdfjs-dist/legacy/build/pdf.mjs");
+  const loadingTask = pdfjsLib.getDocument({ data: new Uint8Array(buf) });
+  const pdf = await loadingTask.promise;
+
+  const parts: string[] = [];
+  for (let i = 1; i <= pdf.numPages; i++) {
+    const page = await pdf.getPage(i);
+    const content = await page.getTextContent();
+    const pageText = content.items
+      .map((item) => ("str" in item ? item.str : ""))
+      .join(" ")
+      .trim();
+    if (pageText) parts.push(pageText);
+  }
+
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
+async function extractFromImage(buf: Buffer): Promise<string> {
+  const worker = await getTesseractWorker();
+  const { data } = await worker.recognize(buf);
+  return data.text.trim();
+}
+
+async function extractFromDocx(buf: Buffer): Promise<string> {
+  const mammoth = await import("mammoth");
+  const result = await mammoth.extractRawText({ buffer: buf });
+  return result.value.trim();
+}
+
+async function extractFromXlsx(buf: Buffer): Promise<string> {
+  const wb = XLSX.read(buf, { type: "buffer" });
+  const parts: string[] = [];
+  for (const sheetName of wb.SheetNames) {
+    const sheet = wb.Sheets[sheetName];
+    if (!sheet) continue;
+    const csv = XLSX.utils.sheet_to_csv(sheet);
+    if (csv.trim()) parts.push(csv.trim());
+  }
+  return parts.join("\n");
+}
+
+async function extractFromPptx(buf: Buffer): Promise<string> {
+  // pptx files are zip archives — extract text nodes from slide XML manually.
+  const { default: JSZip } = await import("jszip");
+  const zip = await JSZip.loadAsync(buf);
+  const parts: string[] = [];
+  const slideFiles = Object.keys(zip.files).filter((name) =>
+    /^ppt\/slides\/slide\d+\.xml$/.test(name),
+  );
+  slideFiles.sort();
+  for (const slideFile of slideFiles) {
+    const entry = zip.files[slideFile];
+    if (!entry) continue;
+    const xml = await entry.async("string");
+    // Extract all <a:t> text elements
+    const matches = xml.matchAll(/<a:t[^>]*>([^<]*)<\/a:t>/g);
+    const texts = [...matches].map((m) => m[1] ?? "").filter(Boolean);
+    if (texts.length) parts.push(texts.join(" "));
+  }
+  return parts.join("\n");
+}
+
+function extractFromSvg(buf: Buffer): string {
+  const svg = buf.toString("utf-8");
+  const matches = svg.matchAll(/<text[^>]*>([\s\S]*?)<\/text>/gi);
+  return [...matches]
+    .map((m) => (m[1] ?? "").replace(/<[^>]+>/g, "").trim())
+    .filter(Boolean)
+    .join(" ");
+}
+
+/**
+ * Extract plain text from a file at the given public URL.
+ * Returns null when the format is not supported or yields no text (skipped).
+ */
+export async function extractText(
+  fileUrl: string,
+  format: string | null | undefined,
+): Promise<{ text: string | null; skipped: boolean }> {
+  const fmt = (format ?? "").toLowerCase();
+
+  // Plain text formats — just fetch and decode, no heavy libs needed.
+  if (fmt === "txt" || fmt === "csv") {
+    const buf = await fetchBuffer(fileUrl);
+    return { text: buf.toString("utf-8").trim() || null, skipped: false };
+  }
+
+  if (fmt === "pdf") {
+    const buf = await fetchBuffer(fileUrl);
+    const text = await extractFromPdf(buf);
+    if (text === null) {
+      // No text layer — scanned PDF, skip per product decision.
+      return { text: null, skipped: true };
+    }
+    return { text, skipped: false };
+  }
+
+  if (fmt === "png" || fmt === "jpg" || fmt === "jpeg" || fmt === "gif") {
+    const buf = await fetchBuffer(fileUrl);
+    const text = await extractFromImage(buf);
+    return { text: text || null, skipped: false };
+  }
+
+  if (fmt === "docx" || fmt === "doc") {
+    const buf = await fetchBuffer(fileUrl);
+    const text = await extractFromDocx(buf);
+    return { text: text || null, skipped: false };
+  }
+
+  if (fmt === "xlsx" || fmt === "xls") {
+    const buf = await fetchBuffer(fileUrl);
+    const text = await extractFromXlsx(buf);
+    return { text: text || null, skipped: false };
+  }
+
+  if (fmt === "pptx" || fmt === "ppt") {
+    const buf = await fetchBuffer(fileUrl);
+    const text = await extractFromPptx(buf);
+    return { text: text || null, skipped: false };
+  }
+
+  if (fmt === "svg") {
+    const buf = await fetchBuffer(fileUrl);
+    const text = extractFromSvg(buf);
+    return { text: text || null, skipped: false };
+  }
+
+  // Unsupported format
+  return { text: null, skipped: true };
+}

--- a/apps/web/src/pages/content/components/ContentCard.tsx
+++ b/apps/web/src/pages/content/components/ContentCard.tsx
@@ -11,6 +11,7 @@ type CheckinMutation = {
 type Props = {
   item: ContentItem;
   currentUserId?: string;
+  searchQuery?: string;
   toggleFavorite: {
     mutate: (args: { fileID: string }) => void;
   };
@@ -27,6 +28,7 @@ function checkedOutLabel(isCheckedOutByMe: boolean, name: string | undefined): s
 export function ContentCard({
   item,
   currentUserId,
+  searchQuery,
   toggleFavorite,
   checkin,
   getStatusBadge,
@@ -39,9 +41,13 @@ export function ContentCard({
   const isCheckedOutByMe = !!(item.is_checked_out && item.checked_out_by === currentUserId);
   const checkedOutByName = item.checked_out_by_user?.name;
 
+  const detailHref = searchQuery
+    ? `/hero/content/${item.fileID}/edit?q=${encodeURIComponent(searchQuery)}`
+    : `/hero/content/${item.fileID}/edit`;
+
   return (
     <Link
-      to={`/hero/content/${item.fileID}/edit`}
+      to={detailHref}
       className="group rounded border border-border bg-card shadow-sm transition-all hover:border-hanover-green hover:shadow-md p-5"
     >
       {/* HEADER */}
@@ -153,6 +159,25 @@ export function ContentCard({
           )}
         </div>
       )}
+
+      {/* OCR BADGES */}
+      <div className="mb-2 flex flex-wrap gap-1">
+        {item.matched_in_content && (
+          <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+            matched in content
+          </span>
+        )}
+        {(item.ocr_status === "pending" || item.ocr_status === "processing") && (
+          <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+            indexing…
+          </span>
+        )}
+        {item.ocr_status === "failed" && (
+          <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-600">
+            OCR failed
+          </span>
+        )}
+      </div>
 
       {/* FOOTER */}
       <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">

--- a/apps/web/src/pages/content/components/ContentGrid.tsx
+++ b/apps/web/src/pages/content/components/ContentGrid.tsx
@@ -20,6 +20,7 @@ type Props = {
   filtered: ContentItem[];
   filters: Filters;
   currentUserId?: string;
+  searchQuery?: string;
   toggleFavorite: {
     mutate: (args: { fileID: string }) => void;
   };
@@ -32,6 +33,7 @@ export function ContentGrid({
   filtered,
   filters,
   currentUserId,
+  searchQuery,
   toggleFavorite,
   checkin,
   getStatusBadge,
@@ -56,6 +58,7 @@ export function ContentGrid({
                 key={item.fileID}
                 item={item}
                 currentUserId={currentUserId}
+                searchQuery={searchQuery}
                 toggleFavorite={toggleFavorite}
                 checkin={checkin}
                 getStatusBadge={getStatusBadge}
@@ -65,6 +68,7 @@ export function ContentGrid({
                 key={item.fileID}
                 item={item}
                 currentUserId={currentUserId}
+                searchQuery={searchQuery}
                 toggleFavorite={toggleFavorite}
                 checkin={checkin}
                 getStatusBadge={getStatusBadge}

--- a/apps/web/src/pages/content/components/ContentListItem.tsx
+++ b/apps/web/src/pages/content/components/ContentListItem.tsx
@@ -11,6 +11,7 @@ type CheckinMutation = {
 type Props = {
   item: ContentItem;
   currentUserId?: string;
+  searchQuery?: string;
   toggleFavorite: {
     mutate: (args: { fileID: string }) => void;
   };
@@ -27,6 +28,7 @@ function checkedOutLabel(isCheckedOutByMe: boolean, name: string | undefined): s
 export function ContentListItem({
   item,
   currentUserId,
+  searchQuery,
   toggleFavorite,
   checkin,
   getStatusBadge,
@@ -39,9 +41,13 @@ export function ContentListItem({
   const isCheckedOutByMe = !!(item.is_checked_out && item.checked_out_by === currentUserId);
   const checkedOutByName = item.checked_out_by_user?.name;
 
+  const detailHref = searchQuery
+    ? `/hero/content/${item.fileID}/edit?q=${encodeURIComponent(searchQuery)}`
+    : `/hero/content/${item.fileID}/edit`;
+
   return (
     <Link
-      to={`/hero/content/${item.fileID}/edit`}
+      to={detailHref}
       className="group flex items-center justify-between rounded border border-border bg-card p-3 shadow-sm transition-all hover:border-hanover-green hover:shadow-md"
     >
       {/* LEFT SIDE */}
@@ -72,6 +78,25 @@ export function ContentListItem({
           <span>
             {item.last_modified ? new Date(item.last_modified).toLocaleDateString() : "—"}
           </span>
+        </div>
+
+        {/* OCR BADGES */}
+        <div className="flex flex-wrap gap-1">
+          {item.matched_in_content && (
+            <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+              matched in content
+            </span>
+          )}
+          {(item.ocr_status === "pending" || item.ocr_status === "processing") && (
+            <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+              indexing…
+            </span>
+          )}
+          {item.ocr_status === "failed" && (
+            <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-600">
+              OCR failed
+            </span>
+          )}
         </div>
       </div>
 

--- a/apps/web/src/pages/content/content-form.tsx
+++ b/apps/web/src/pages/content/content-form.tsx
@@ -4,7 +4,7 @@ import { TextInput } from "@myapp/ui/components/text-input";
 import "@iamjariwala/react-doc-viewer/dist/index.css";
 import { ArrowLeft, Loader2, Lock, Pencil, Unlock } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 import { useSession } from "@/auth/session-context";
 import { useFileUpload } from "@/hooks/use-file-upload";
 import { type RouterOutputs, trpc } from "@/lib/trpc.ts";
@@ -61,7 +61,71 @@ type ContentFormFieldsProps = {
   isSaving: boolean;
   onDelete: () => void;
   onSubmit: (e: React.FormEvent) => void;
+  extractedText?: string | null;
 };
+
+// Walk DOM text nodes and wrap matches in <mark> without touching React-managed nodes.
+function highlightTextNodes(root: Element, re: RegExp) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const matches: [Text, string][] = [];
+
+  let node: Node | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard TreeWalker pattern
+  while ((node = walker.nextNode())) {
+    const text = (node as Text).textContent ?? "";
+    if (re.test(text)) matches.push([node as Text, text]);
+    re.lastIndex = 0;
+  }
+
+  for (const [textNode, raw] of matches) {
+    const span = document.createElement("span");
+    span.innerHTML = raw.replace(
+      re,
+      '<mark style="background:#fef08a;border-radius:2px;padding:0 1px">$1</mark>',
+    );
+    re.lastIndex = 0;
+    textNode.parentNode?.replaceChild(span, textNode);
+  }
+}
+
+function HighlightedExcerpt({ text, query }: { text: string; query: string }) {
+  const CONTEXT = 120;
+  const lower = text.toLowerCase();
+  const queryLower = query.toLowerCase().trim();
+
+  if (!queryLower) return null;
+
+  // Find the first occurrence to anchor the excerpt.
+  const idx = lower.indexOf(queryLower);
+  if (idx === -1) return null;
+
+  const start = Math.max(0, idx - CONTEXT);
+  const end = Math.min(text.length, idx + queryLower.length + CONTEXT);
+  const excerpt = (start > 0 ? "…" : "") + text.slice(start, end) + (end < text.length ? "…" : "");
+
+  // Split excerpt on all occurrences of the query word (case-insensitive) for highlighting.
+  const parts = excerpt.split(new RegExp(`(${queryLower})`, "gi"));
+
+  return (
+    <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm">
+      <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-blue-600">
+        Matched in document content
+      </p>
+      <p className="leading-relaxed text-foreground">
+        {parts.map((part, i) =>
+          part.toLowerCase() === queryLower ? (
+            // biome-ignore lint/suspicious/noArrayIndexKey: split-on-regex parts have no stable identity
+            <mark key={i} className="rounded bg-yellow-200 px-0.5 text-foreground">
+              {part}
+            </mark>
+          ) : (
+            part
+          ),
+        )}
+      </p>
+    </div>
+  );
+}
 
 function ContentMetadataReadonlyTable({
   fileID,
@@ -627,8 +691,11 @@ function ContentFormFields({
   isSaving,
   onDelete,
   onSubmit,
+  extractedText,
 }: ContentFormFieldsProps) {
   const [metadataEditMode, setMetadataEditMode] = useState(false);
+  const [searchParams] = useSearchParams();
+  const searchQuery = searchParams.get("q") ?? "";
   const showFileSummary = isEditing && Boolean(url) && !metadataEditMode;
   const ownerDisplayName =
     employees?.find((e) => e.id === ownerId)?.name ?? (ownerId ? ownerId : "Unassigned");
@@ -666,6 +733,71 @@ function ContentFormFields({
     return () => observer.disconnect();
   }, [url, filename]);
 
+  // Highlight search terms inside the DocViewer once it finishes rendering.
+  useEffect(() => {
+    if (!searchQuery || !url) return;
+
+    const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+    const escaped = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const queryRe = new RegExp(`(${escaped})`, "gi");
+
+    function applyHighlights() {
+      // ── Plain text / CSV ────────────────────────────────────────────────
+      const txtContainer = document.querySelector(".rdv-txt-container");
+      if (txtContainer && (ext === "txt" || ext === "csv")) {
+        const raw = txtContainer.textContent ?? "";
+        if (!raw) return false;
+        txtContainer.innerHTML = raw.replace(
+          queryRe,
+          '<mark style="background:#fef08a;border-radius:2px;padding:0 1px">$1</mark>',
+        );
+        txtContainer.querySelector("mark")?.scrollIntoView({ behavior: "smooth", block: "center" });
+        return true;
+      }
+
+      // ── DOCX / DOC ──────────────────────────────────────────────────────
+      const msdocContainer = document.querySelector(".rdv-msdoc-content");
+      if (msdocContainer && (ext === "docx" || ext === "doc")) {
+        highlightTextNodes(msdocContainer, queryRe);
+        msdocContainer
+          .querySelector("mark")
+          ?.scrollIntoView({ behavior: "smooth", block: "center" });
+        return true;
+      }
+
+      // ── PDF text layer ──────────────────────────────────────────────────
+      // PDF.js renders an invisible text layer (.textLayer) on top of the canvas.
+      // We tint matching spans so the highlight aligns with the visible glyphs.
+      if (ext === "pdf") {
+        const textLayerSpans = document.querySelectorAll<HTMLElement>(
+          ".textLayer span, .text-layer span",
+        );
+        if (textLayerSpans.length === 0) return false;
+
+        let firstMatch: HTMLElement | null = null;
+        for (const span of textLayerSpans) {
+          if (queryRe.test(span.textContent ?? "")) {
+            span.style.backgroundColor = "#fef08a";
+            span.style.borderRadius = "2px";
+            if (!firstMatch) firstMatch = span;
+          }
+          queryRe.lastIndex = 0; // reset stateful regex after each test
+        }
+        firstMatch?.scrollIntoView({ behavior: "smooth", block: "center" });
+        return true;
+      }
+
+      return false;
+    }
+
+    // Retry until the DocViewer finishes rendering, then stop.
+    const observer = new MutationObserver(() => {
+      if (applyHighlights()) observer.disconnect();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [searchQuery, url, filename]);
+
   const docs = [{ uri: url }];
   return (
     <div className="border-t border-border/60 py-8 sm:py-10">
@@ -683,6 +815,9 @@ function ContentFormFields({
         </h1>
 
         <div className="rounded-xl border border-border bg-card p-6 shadow-md sm:p-8">
+          {searchQuery && extractedText && (
+            <HighlightedExcerpt text={extractedText} query={searchQuery} />
+          )}
           {url && canDisplayDocument(url) ? (
             <div className="mb-6 text-black overflow-hidden rounded-lg border border-border bg-muted">
               <style>{`.rdv-txt-container { white-space: pre; font-family: monospace; }`}</style>
@@ -1091,6 +1226,7 @@ function ContentFormPage() {
         isSaving={isSaving}
         onDelete={handleDelete}
         onSubmit={handleSubmit}
+        extractedText={existing.data?.extracted_text}
       />
       {askConfirmation && (
         <div className="bg-black/50 fixed inset-0 flex items-center justify-center">

--- a/apps/web/src/pages/content/page.tsx
+++ b/apps/web/src/pages/content/page.tsx
@@ -107,7 +107,7 @@ export default function ContentPage() {
               <input
                 value={filters.search}
                 onChange={(e) => filters.setSearch(e.target.value)}
-                placeholder="Search by filename or URL..."
+                placeholder="Search by filename or document content..."
                 className="w-full rounded border border-border bg-background py-2 pl-10 pr-4 text-sm"
               />
             </div>
@@ -161,6 +161,7 @@ export default function ContentPage() {
             filtered={filtered}
             filters={filters}
             currentUserId={currentUserId}
+            searchQuery={debouncedSearch}
             toggleFavorite={toggleFavorite}
             checkin={checkin}
             getStatusBadge={getStatusBadge}

--- a/apps/web/src/types/content.ts
+++ b/apps/web/src/types/content.ts
@@ -1,3 +1,5 @@
+export type OcrStatus = "pending" | "processing" | "done" | "failed" | "skipped";
+
 export type ContentItem = {
   fileID: string;
   filename?: string;
@@ -13,4 +15,6 @@ export type ContentItem = {
   owner?: { name?: string };
   content_tags?: { tag: { id: number; name: string } }[];
   url?: string;
+  ocr_status?: OcrStatus;
+  matched_in_content?: boolean;
 };

--- a/apps/web/src/utils/normalizeContent.ts
+++ b/apps/web/src/utils/normalizeContent.ts
@@ -1,4 +1,4 @@
-import type { ContentItem } from "@/types/content";
+import type { ContentItem, OcrStatus } from "@/types/content";
 
 type RawContentItem = Partial<ContentItem> & {
   url?: string;
@@ -25,5 +25,7 @@ export function normalizeContent(item: unknown): ContentItem {
     owner: data.owner ?? undefined,
     content_tags: data.content_tags ?? undefined,
     url: data.url ?? undefined,
+    ocr_status: (data.ocr_status ?? "pending") as OcrStatus,
+    matched_in_content: data.matched_in_content ?? false,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,16 +47,34 @@ importers:
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
+      mammoth:
+        specifier: ^1.12.0
+        version: 1.12.0
+      pdfjs-dist:
+        specifier: ^5.7.284
+        version: 5.7.284
       pg:
         specifier: ^8.20.0
         version: 8.20.0
       prisma:
         specifier: ^7.6.0
         version: 7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      tesseract.js:
+        specifier: ^7.0.0
+        version: 7.0.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^3.24.0
         version: 3.25.76
     devDependencies:
+      '@types/jszip':
+        specifier: ^3.4.1
+        version: 3.4.1
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
@@ -736,6 +754,81 @@ packages:
 
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
@@ -1975,6 +2068,10 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/jszip@3.4.1':
+    resolution: {integrity: sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A==}
+    deprecated: This is a stub types definition. jszip provides its own type definitions, so you do not need this installed.
+
   '@types/mustache@4.2.6':
     resolution: {integrity: sha512-t+8/QWTAhOFlrF1IVZqKnMRJi84EgkIK5Kh0p2JV4OLywUvCwJPFxbJAl7XAow7DVIHsF+xW9f1MVzg0L6Szjw==}
 
@@ -2046,8 +2143,16 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
+
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
+
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
 
   agent-base@9.0.0:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
@@ -2084,6 +2189,9 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -2115,6 +2223,12 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
+
+  bmp-js@0.1.0:
+    resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
 
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
@@ -2153,6 +2267,10 @@ packages:
   canvas@3.2.3:
     resolution: {integrity: sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==}
     engines: {node: ^18.12.0 || >= 20.9.0}
+
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -2214,6 +2332,10 @@ packages:
     resolution: {integrity: sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2252,6 +2374,11 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2376,6 +2503,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  dingbat-to-unicode@1.0.1:
+    resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
+
   docx-preview-sync@0.4.20:
     resolution: {integrity: sha512-g4DnVPq4UDLYsqZA+Yz/wBohOfQocYvKKYK8ye0nCk6AwYrRYUIDIx9isiarIMOKings39YQ2dZITCATsF0DbA==}
 
@@ -2385,6 +2515,9 @@ packages:
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
+
+  duck@0.1.12:
+    resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2485,6 +2618,10 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
+
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
     peerDependencies:
@@ -2571,6 +2708,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  idb-keyval@6.2.2:
+    resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -2615,6 +2755,9 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -2741,6 +2884,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lop@0.4.2:
+    resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -2765,6 +2911,11 @@ packages:
 
   make-event-props@1.6.2:
     resolution: {integrity: sha512-iDwf7mA03WPiR8QxvcVHmVWEPfMY1RZXerDVNCRYW7dUr2ppH3J58Rwb39/WG39yTZdRSxr3x+2v22tvI0VEvA==}
+
+  mammoth@1.12.0:
+    resolution: {integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -2868,6 +3019,15 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2899,6 +3059,13 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  opencollective-postinstall@2.0.3:
+    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
+    hasBin: true
+
+  option@0.2.4:
+    resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -2907,6 +3074,10 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-is-inside@1.0.2:
     resolution: {integrity: sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==}
@@ -2932,6 +3103,10 @@ packages:
   pdfjs-dist@4.8.69:
     resolution: {integrity: sha512-IHZsA4T7YElCKNNXtiLgqScw4zPd3pG9do8UrznC757gMd7UPeHSL2qwNNMJo4r79fl8oj1Xx+1nh2YkzdMpLQ==}
     engines: {node: '>=18'}
+
+  pdfjs-dist@5.7.284:
+    resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
+    engines: {node: '>=22.13.0 || >=24'}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -3176,6 +3351,9 @@ packages:
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   registry-auth-token@3.3.2:
     resolution: {integrity: sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==}
 
@@ -3283,9 +3461,16 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
+
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3378,6 +3563,12 @@ packages:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
 
+  tesseract.js-core@7.0.0:
+    resolution: {integrity: sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==}
+
+  tesseract.js@7.0.0:
+    resolution: {integrity: sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -3418,6 +3609,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -3450,6 +3644,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -3630,9 +3827,15 @@ packages:
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
+  wasm-feature-detect@1.8.0:
+    resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -3645,6 +3848,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3659,6 +3865,14 @@ packages:
   widest-line@4.0.1:
     resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
     engines: {node: '>=12'}
+
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
@@ -3683,9 +3897,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xmlbuilder@10.1.1:
+    resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
+    engines: {node: '>=4.0'}
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
@@ -3700,6 +3923,9 @@ packages:
 
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
+
+  zlibjs@0.3.1:
+    resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -4088,6 +4314,54 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@kurkle/color@0.3.4': {}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
@@ -5281,6 +5555,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/jszip@3.4.1':
+    dependencies:
+      jszip: 3.10.1
+
   '@types/mustache@4.2.6': {}
 
   '@types/node@22.19.15':
@@ -5361,7 +5639,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@xmldom/xmldom@0.8.13': {}
+
   '@zeit/schemas@2.36.0': {}
+
+  adler-32@1.3.1: {}
 
   agent-base@9.0.0: {}
 
@@ -5397,6 +5679,10 @@ snapshots:
 
   arg@5.0.2: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -5407,8 +5693,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
 
   better-result@2.7.0:
     dependencies:
@@ -5432,6 +5717,10 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
     optional: true
+
+  bluebird@3.4.7: {}
+
+  bmp-js@0.1.0: {}
 
   boxen@7.0.0:
     dependencies:
@@ -5483,6 +5772,11 @@ snapshots:
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
     optional: true
+
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
 
   chai@5.3.3:
     dependencies:
@@ -5540,6 +5834,8 @@ snapshots:
 
   cmd-shim@8.0.0: {}
 
+  codepage@1.15.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5575,6 +5871,8 @@ snapshots:
   core-js@3.49.0: {}
 
   core-util-is@1.0.3: {}
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5671,6 +5969,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  dingbat-to-unicode@1.0.1: {}
+
   docx-preview-sync@0.4.20:
     dependencies:
       jszip: 3.10.1
@@ -5682,6 +5982,10 @@ snapshots:
       '@types/trusted-types': 2.0.7
 
   dotenv@16.6.1: {}
+
+  duck@0.1.12:
+    dependencies:
+      underscore: 1.13.8
 
   eastasianwidth@0.2.0: {}
 
@@ -5823,6 +6127,8 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  frac@1.1.2: {}
+
   framer-motion@12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       motion-dom: 12.38.0
@@ -5898,6 +6204,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb-keyval@6.2.2: {}
+
   ieee754@1.2.1:
     optional: true
 
@@ -5924,6 +6232,8 @@ snapshots:
   is-property@1.0.2: {}
 
   is-stream@2.0.1: {}
+
+  is-url@1.2.4: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -6039,6 +6349,12 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lop@0.4.2:
+    dependencies:
+      duck: 0.1.12
+      option: 0.2.4
+      underscore: 1.13.8
+
   loupe@3.2.1: {}
 
   lru-cache@11.2.7: {}
@@ -6056,6 +6372,19 @@ snapshots:
   make-cancellable-promise@1.3.2: {}
 
   make-event-props@1.6.2: {}
+
+  mammoth@1.12.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      argparse: 1.0.10
+      base64-js: 1.5.1
+      bluebird: 3.4.7
+      dingbat-to-unicode: 1.0.1
+      jszip: 3.10.1
+      lop: 0.4.2
+      path-is-absolute: 1.0.1
+      underscore: 1.13.8
+      xmlbuilder: 10.1.1
 
   mdn-data@2.27.1: {}
 
@@ -6140,6 +6469,10 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -6171,6 +6504,10 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  opencollective-postinstall@2.0.3: {}
+
+  option@0.2.4: {}
+
   pako@1.0.11: {}
 
   papaparse@5.5.3: {}
@@ -6178,6 +6515,8 @@ snapshots:
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
+
+  path-is-absolute@1.0.1: {}
 
   path-is-inside@1.0.2: {}
 
@@ -6196,6 +6535,10 @@ snapshots:
     optionalDependencies:
       canvas: 3.2.3
       path2d: 0.2.2
+
+  pdfjs-dist@5.7.284:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
 
   perfect-debounce@1.0.0: {}
 
@@ -6509,6 +6852,8 @@ snapshots:
 
   redux@5.0.1: {}
 
+  regenerator-runtime@0.13.11: {}
+
   registry-auth-token@3.3.2:
     dependencies:
       rc: 1.2.8
@@ -6658,7 +7003,13 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.0.3: {}
+
   sqlstring@2.3.3: {}
+
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
 
   stackback@0.0.2: {}
 
@@ -6758,6 +7109,22 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  tesseract.js-core@7.0.0: {}
+
+  tesseract.js@7.0.0:
+    dependencies:
+      bmp-js: 0.1.0
+      idb-keyval: 6.2.2
+      is-url: 1.2.4
+      node-fetch: 2.7.0
+      opencollective-postinstall: 2.0.3
+      regenerator-runtime: 0.13.11
+      tesseract.js-core: 7.0.0
+      wasm-feature-detect: 1.8.0
+      zlibjs: 0.3.1
+    transitivePeerDependencies:
+      - encoding
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -6786,6 +7153,8 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.27
+
+  tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
@@ -6819,6 +7188,8 @@ snapshots:
   typescript@5.8.3: {}
 
   typescript@5.9.3: {}
+
+  underscore@1.13.8: {}
 
   undici-types@6.21.0: {}
 
@@ -6981,7 +7352,11 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  wasm-feature-detect@1.8.0: {}
+
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
 
@@ -6995,6 +7370,11 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -7007,6 +7387,10 @@ snapshots:
   widest-line@4.0.1:
     dependencies:
       string-width: 5.1.2
+
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@8.1.0:
     dependencies:
@@ -7023,7 +7407,19 @@ snapshots:
 
   ws@8.20.0: {}
 
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
+
   xml-name-validator@5.0.0: {}
+
+  xmlbuilder@10.1.1: {}
 
   xmlchars@2.2.0: {}
 
@@ -7035,6 +7431,8 @@ snapshots:
     dependencies:
       grammex: 3.1.12
       graphmatch: 1.1.1
+
+  zlibjs@0.3.1: {}
 
   zod@3.25.76: {}
 

--- a/supabase/migrations/20260427000003_add_ocr_columns.sql
+++ b/supabase/migrations/20260427000003_add_ocr_columns.sql
@@ -1,0 +1,22 @@
+-- Add OCR status enum
+CREATE TYPE public.ocr_status AS ENUM ('pending', 'processing', 'done', 'failed', 'skipped');
+
+-- Add OCR columns to content_management
+ALTER TABLE public.content_management
+  ADD COLUMN extracted_text  TEXT         NULL,
+  ADD COLUMN ocr_status      public.ocr_status NOT NULL DEFAULT 'pending',
+  ADD COLUMN ocr_error       TEXT         NULL,
+  ADD COLUMN ocr_updated_at  TIMESTAMPTZ  NULL;
+
+-- Generated tsvector column (filename weighted A, extracted_text weighted B)
+ALTER TABLE public.content_management
+  ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('english', coalesce(filename, '')), 'A') ||
+      setweight(to_tsvector('english', coalesce(extracted_text, '')), 'B')
+    ) STORED;
+
+-- GIN index for fast full-text search
+CREATE INDEX content_search_vector_idx
+  ON public.content_management
+  USING GIN (search_vector);


### PR DESCRIPTION
- Added OCR extraction pipeline that runs automatically on upload/update, supporting PDF (text layer), DOCX, XLSX, PPTX, TXT, CSV, images (Tesseract), and SVG
- Stored extracted text in Postgres with a generated tsvector column + GIN index for fast full-text search
- Replaced filename-only search with tsvector full-text search; results now surface documents matched by body content with a "matched in content" badge
- Added in-viewer search highlighting: yellow marks injected into the PDF text layer, plain-text container, and Word doc renderer after DocViewer renders
- Added "Matched in content" excerpt panel on the document detail page with the surrounding snippet highlighted
- Added OCR status badges (indexing… / OCR failed) on content cards
- Added one-time backfill script (pnpm --filter @myapp/api ocr:backfill) to index all existing documents