### PR TITLE
Fix fresh install without database env

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     }
   },
   "scripts": {
-    "postinstall": "node -e \"if (process.env.CI) process.exit(0); require('child_process').execSync('prisma generate', { stdio: 'inherit' })\"",
+    "postinstall": "node -e \"if (process.env.CI) process.exit(0); require('child_process').execSync('PRISMA_ALLOW_PLACEHOLDER_DATABASE_URL=1 prisma generate', { stdio: 'inherit' })\"",
     "dev": "tsx watch src/server.ts",
     "build": "prisma generate && node build.mjs",
     "start": "node dist/server.mjs",

--- a/apps/api/prisma.config.ts
+++ b/apps/api/prisma.config.ts
@@ -34,9 +34,14 @@ let databaseUrl: string | undefined = (() => {
 })();
 
 if (!databaseUrl) {
-  // `prisma generate` and bundled API builds do not open a DB connection; Prisma still loads this config.
-  // CI / Railway builds often have no repo `.env` — use a well-formed placeholder for config parsing only.
-  if (process.env.CI === "true" || process.env.RAILWAY_ENVIRONMENT) {
+  // `prisma generate` does not open a DB connection, but Prisma still loads this config.
+  // Fresh installs may not have a local `.env` yet, so postinstall can explicitly allow a
+  // well-formed placeholder for config parsing only.
+  if (
+    process.env.CI === "true" ||
+    process.env.RAILWAY_ENVIRONMENT ||
+    process.env.PRISMA_ALLOW_PLACEHOLDER_DATABASE_URL === "1"
+  ) {
     databaseUrl = "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
   } else {
     throw new Error(


### PR DESCRIPTION
## Summary
- Allow API postinstall Prisma client generation to use a placeholder database URL
- Keep normal Prisma database commands strict unless CI/Railway/postinstall explicitly allows the placeholder

## Verification
- Fresh worktree without .env.local: pnpm install --frozen-lockfile
- pnpm install --frozen-lockfile
- pnpm exec biome ci .
- pnpm exec turbo run typecheck --force
- pnpm exec turbo run build --force
- pnpm exec turbo run test --force